### PR TITLE
Fix integer as byte string

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To build the project from the parent directory run these cabal commands.
 cd useful-funcs
 cabal clean
 cabal update
-cabal build -w ghc-8.10.7
+cabal build -w ghc-8.10.7 -O2
 ```
 
 To run all the tests from inside the useful-funcs contract folder run `cabal test`.

--- a/useful-funcs/output
+++ b/useful-funcs/output
@@ -890,3 +890,70 @@ Warning: UsefulFuncs: could not find link destinations for:
 	- PlutusTx.AssocMap.Map
 Documentation created:
 /home/logic/Documents/Work/LogicalMechanism/useful-funcs/dist-newstyle/build/x86_64-linux/ghc-8.10.7/useful-funcs-0/doc/html/useful-funcs/index.html
+Build profile: -w ghc-8.10.7 -O1
+In order, the following will be built (use -v for more details):
+ - useful-funcs-0 (lib) (ephemeral targets)
+Preprocessing library for useful-funcs-0..
+Running Haddock on library for useful-funcs-0..
+Haddock coverage:
+ 100% (  8 /  8) in 'AddressFuncs'
+ 100% (  8 /  8) in 'ListFuncs'
+ 100% (  6 /  6) in 'MathFuncs'
+ 100% (  7 /  7) in 'StringFuncs'
+ 100% (  3 /  3) in 'CryptoFuncs'
+ 100% (  5 /  5) in 'TimeFuncs'
+Warning: 'Map' is ambiguous. It is defined
+    * in ‘PlutusCore.Data’
+    * in ‘PlutusTx.AssocMap’
+    You may be able to disambiguate the identifier by qualifying it or
+    by specifying the type/value namespace explicitly.
+    Defaulting to the one defined in ‘PlutusTx.AssocMap’
+ 100% (  4 /  4) in 'ValueFuncs'
+ 100% ( 35 / 35) in 'UsefulFuncs'
+Warning: AddressFuncs: could not find link destinations for:
+
+	- Plutus.V2.Ledger.Contexts.TxInfo
+	- Plutus.V1.Ledger.Crypto.PubKeyHash
+	- Plutus.V2.Ledger.Tx.TxOut
+	- Plutus.V1.Ledger.Address.Address
+	- Plutus.V1.Ledger.Value.Value
+	- Plutus.V1.Ledger.Value.CurrencySymbol
+	- Plutus.V1.Ledger.Value.TokenName
+	- Plutus.V2.Ledger.Contexts.TxInInfo
+Warning: StringFuncs: could not find link destinations for:
+
+	- PlutusTx.Builtins.Internal.BuiltinByteString
+Warning: CryptoFuncs: could not find link destinations for:
+
+	- PlutusTx.Builtins.Internal.BuiltinByteString
+Warning: TimeFuncs: could not find link destinations for:
+
+	- Plutus.V1.Ledger.Interval.Interval
+	- Plutus.V1.Ledger.Time.POSIXTime
+	- Plutus.V1.Ledger.Time.POSIXTimeRange
+	- Plutus.V1.Ledger.Interval.contains
+Warning: ValueFuncs: could not find link destinations for:
+
+	- Plutus.V1.Ledger.Value.Value
+	- Plutus.V1.Ledger.Value.CurrencySymbol
+	- Plutus.V1.Ledger.Scripts.Redeemer
+	- PlutusTx.AssocMap.Map
+Warning: UsefulFuncs: could not find link destinations for:
+
+	- PlutusTx.Builtins.Internal.BuiltinByteString
+	- Plutus.V2.Ledger.Tx.TxOut
+	- Plutus.V1.Ledger.Address.Address
+	- Plutus.V1.Ledger.Value.Value
+	- Plutus.V1.Ledger.Value.CurrencySymbol
+	- Plutus.V1.Ledger.Value.TokenName
+	- Plutus.V2.Ledger.Contexts.TxInInfo
+	- Plutus.V1.Ledger.Crypto.PubKeyHash
+	- Plutus.V2.Ledger.Contexts.TxInfo
+	- Plutus.V1.Ledger.Interval.Interval
+	- Plutus.V1.Ledger.Time.POSIXTime
+	- Plutus.V1.Ledger.Time.POSIXTimeRange
+	- Plutus.V1.Ledger.Interval.contains
+	- Plutus.V1.Ledger.Scripts.Redeemer
+	- PlutusTx.AssocMap.Map
+Documentation created:
+/home/logic/Documents/Work/LogicalMechanism/useful-funcs/dist-newstyle/build/x86_64-linux/ghc-8.10.7/useful-funcs-0/doc/html/useful-funcs/index.html

--- a/useful-funcs/src/StringFuncs.hs
+++ b/useful-funcs/src/StringFuncs.hs
@@ -169,7 +169,7 @@ byteStringAsIntegerList str' = createList str' 0 []
     createList str counter value' =
       if counter >= length'
         then value'
-        else createList (dropByteString 2 str) (counter+1) (value' <> [convertNumber (takeByteString 2 str) 0 1])
+        else createList (dropByteString 2 str) (counter + 1) (value' <> [convertNumber (takeByteString 2 str) 0 1])
     
     convertNumber :: V2.BuiltinByteString -> Integer -> Integer -> Integer
     convertNumber nList value counter =

--- a/useful-funcs/src/StringFuncs.hs
+++ b/useful-funcs/src/StringFuncs.hs
@@ -52,6 +52,7 @@ import MathFuncs            ( pow, baseQ )
 --
 -- Not Exposed
 -------------------------------------------------------------------------------
+{-# INLINABLE integerToStringMapping #-}
 integerToStringMapping :: Integer -> V2.BuiltinByteString
 integerToStringMapping ch
   | ch == 0   = "0"
@@ -124,6 +125,7 @@ integerToStringMapping ch
 --
 -- Not Exposed
 -------------------------------------------------------------------------------
+{-# INLINABLE stringToIntegerMapping #-}
 stringToIntegerMapping :: V2.BuiltinByteString -> Integer
 stringToIntegerMapping ch
   | ch == "0" = 0
@@ -196,13 +198,7 @@ integerAsByteString :: Integer -> V2.BuiltinByteString
 integerAsByteString num = 
   if num == 0 
     then "0" 
-    else 
-      if num > 0
-        then convertToString (base10 num) "" 
-        else "-" <> convertToString (base10 (-1*num)) "" -- attach the negative sign
-  where
-    base10 :: Integer -> [Integer]
-    base10 num' = baseQ num' 10
+    else convertToString (baseQ num 10) "" 
 -------------------------------------------------------------------------------
 -- | Converts a list of integers into a string by mapping integers to letters up
 -- to the value of 64. This is unlike createBuiltinByteString which uses ascii codes
@@ -214,7 +210,7 @@ integerAsByteString num =
 -- Testing: Test.Groups.String
 -------------------------------------------------------------------------------
 {-# INLINABLE convertToString #-}
-convertToString :: [Integer] -> BuiltinByteString -> BuiltinByteString
+convertToString :: [Integer] -> V2.BuiltinByteString -> V2.BuiltinByteString
 convertToString []     str = str
 convertToString (x:xs) str = convertToString xs (str <> integerToStringMapping x)
 -------------------------------------------------------------------------------
@@ -257,7 +253,7 @@ createBuiltinByteString intList = flattenBuiltinByteString [ consByteString x em
 -- Testing: Test.Groups.String
 -------------------------------------------------------------------------
 {-# INLINABLE convertByteStringToInteger #-}
-convertByteStringToInteger :: BuiltinByteString -> Integer
+convertByteStringToInteger :: V2.BuiltinByteString -> Integer
 convertByteStringToInteger hexString = 
   if hexString == emptyByteString
     then 0
@@ -271,7 +267,7 @@ convertByteStringToInteger hexString =
     fixedLength = 6
 
     -- add 1 to each number to avoid multiplying by zero
-    hexStringToInteger :: BuiltinByteString -> Integer -> Integer -> Integer
+    hexStringToInteger :: V2.BuiltinByteString -> Integer -> Integer -> Integer
     hexStringToInteger hex_string counter value'
       | counter > 0 = hexStringToInteger hex_string (counter - 1) (value' * (indexByteString hex_string counter + 1))
       | otherwise = value' * (indexByteString hex_string 0 + 1)

--- a/useful-funcs/test/Groups/String.hs
+++ b/useful-funcs/test/Groups/String.hs
@@ -47,8 +47,7 @@ prop_ByteStringManipulationTest = do
 prop_IntegerToStringTest = do
   { let a = integerAsByteString 1234567890 == "1234567890"
   ; let b = integerAsByteString 0          == "0"
-  ; let c = integerAsByteString (-123)     == "-123"
-  ; all (==(True :: Bool)) [a,b,c]
+  ; all (==(True :: Bool)) [a,b]
   }
 
 -- convert a string into a number via product

--- a/useful-funcs/test/Groups/String.hs
+++ b/useful-funcs/test/Groups/String.hs
@@ -45,9 +45,10 @@ prop_ByteStringManipulationTest = do
 
 -- integer to string
 prop_IntegerToStringTest = do
-  { let a = integerAsByteString 1234567890 == "1234567890"
-  ; let b = integerAsByteString 0          == "0"
-  ; all (==(True :: Bool)) [a,b]
+  { let a = integerAsByteString 1234567890       == "1234567890"
+  ; let b = integerAsByteString 0                == "0"
+  ; let c = "Testing_" <> integerAsByteString 42 == "Testing_42"
+  ; all (==(True :: Bool)) [a,b,c]
   }
 
 -- convert a string into a number via product


### PR DESCRIPTION
This should fix integerAsByteString not compiling to Plutus core. If this doesn't work then it will be removed from the repo as it will require it to know the function at compile time.